### PR TITLE
Feat: MSSR super-resolution + TIFF import (closes #10)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -28,6 +28,7 @@ from ..simulation.emitter_simulator import simulate_blinking_sequence, generate_
 from ..simulation.sofi_pipeline import SOFIPipeline
 from ..simulation.cumulants import compute_sofi_image
 from ..simulation.tiff_loader import load_tiff_stack
+from ..simulation.mssr import compute_mssr, compute_temporal_mssr
 
 
 # --------------- Pydantic Models ---------------
@@ -54,6 +55,15 @@ class ProcessParams(BaseModel):
     deconvolution: str = Field("none", description="Deconvolution method")
     linearize: bool = Field(True, description="Apply nth-root linearization")
     psf_sigma: float = Field(2.0, ge=0.5, le=10.0, description="PSF sigma for deconvolution")
+
+
+class MSSRParams(BaseModel):
+    """Parameters for MSSR processing."""
+
+    mode: str = Field("single", description="'single' for single-frame MSSR, 'temporal' for temporal MSSR")
+    order: int = Field(1, ge=1, le=2, description="MSSR order (1 or 2)")
+    kernel_sigma: float = Field(1.0, ge=0.5, le=5.0, description="Gaussian kernel sigma for mean-shift")
+    frame_index: int = Field(0, ge=0, description="Frame index for single-frame mode")
 
 
 class StateResponse(BaseModel):
@@ -243,6 +253,69 @@ async def process(params: ProcessParams):
         "orders": params.orders,
         "elapsed_seconds": round(elapsed, 3),
         "results": results,
+    }
+
+
+@router.post("/api/process-mssr")
+async def process_mssr(params: MSSRParams):
+    """Run MSSR super-resolution processing on current data.
+
+    Supports single-frame MSSR (instant, from one frame) and
+    temporal MSSR (averaged across all frames for better SNR).
+
+    Returns the MSSR image as a base64-encoded float array.
+    """
+    if app_state.images is None:
+        raise HTTPException(status_code=400, detail="No image data loaded. Run /api/simulate first.")
+
+    start_time = time.time()
+    loop = asyncio.get_event_loop()
+
+    await app_state.broadcast({
+        "type": "progress",
+        "step": f"Computing MSSR ({params.mode}, order {params.order})...",
+        "progress": 0.0,
+    })
+
+    if params.mode == "single":
+        frame_idx = min(params.frame_index, app_state.images.shape[0] - 1)
+        mssr_img = await loop.run_in_executor(
+            None,
+            lambda: compute_mssr(
+                app_state.images[frame_idx],
+                order=params.order,
+                kernel_sigma=params.kernel_sigma,
+            ),
+        )
+    else:
+        mssr_img = await loop.run_in_executor(
+            None,
+            lambda: compute_temporal_mssr(
+                app_state.images,
+                order=params.order,
+                kernel_sigma=params.kernel_sigma,
+            ),
+        )
+
+    elapsed = time.time() - start_time
+
+    await app_state.broadcast({
+        "type": "progress",
+        "step": "MSSR processing complete",
+        "progress": 1.0,
+    })
+
+    return {
+        "status": "ok",
+        "mode": params.mode,
+        "order": params.order,
+        "elapsed_seconds": round(elapsed, 3),
+        "result": {
+            "image": _image_to_base64(mssr_img),
+            "shape": list(mssr_img.shape),
+            "min": float(mssr_img.min()),
+            "max": float(mssr_img.max()),
+        },
     }
 
 

--- a/app/simulation/__init__.py
+++ b/app/simulation/__init__.py
@@ -16,6 +16,7 @@ from .psf import gaussian_psf, airy_psf
 from .deconvolution import wiener_deconvolution, richardson_lucy
 from .fourier_interpolation import fourier_interpolate
 from .sofi_pipeline import SOFIPipeline
+from .mssr import compute_mssr, compute_temporal_mssr
 
 __all__ = [
     "compute_cumulant",
@@ -28,4 +29,6 @@ __all__ = [
     "richardson_lucy",
     "fourier_interpolate",
     "SOFIPipeline",
+    "compute_mssr",
+    "compute_temporal_mssr",
 ]

--- a/app/simulation/mssr.py
+++ b/app/simulation/mssr.py
@@ -1,0 +1,119 @@
+"""
+Mean-Shift Super Resolution (MSSR) — single-frame super-resolution.
+
+MSSR achieves super-resolution from a SINGLE frame by analyzing the
+local intensity distribution around each pixel using mean-shift
+analysis. It identifies sub-pixel emitter positions from the local
+gradient structure.
+
+The algorithm:
+1. For each pixel, compute the local mean shift vector:
+   m(x) = (Σ K(x-xi) * xi * I(xi)) / (Σ K(x-xi) * I(xi)) - x
+   where K is a Gaussian kernel and I is the intensity.
+
+2. The mean shift magnitude |m(x)| indicates proximity to an emitter:
+   - Near an emitter center: |m| ≈ 0 (convergence point)
+   - On the slope of a PSF: |m| points toward the center
+
+3. The MSSR image is constructed as:
+   MSSR(x) = I(x) / (|m(x)| + epsilon)
+   This sharpens peaks (small |m|) and suppresses slopes (large |m|).
+
+Resolution improvement: ~1.5-2x from a SINGLE frame.
+Temporal resolution: same as camera frame rate (no stacking needed).
+
+References:
+    - Torres-García et al. (2022), Extending resolution within a
+      single imaging frame, Nature Communications 13:7452
+"""
+import numpy as np
+from scipy.ndimage import uniform_filter, gaussian_filter
+
+
+def compute_mssr(image: np.ndarray, order: int = 1,
+                  kernel_sigma: float = 1.0) -> np.ndarray:
+    """Compute MSSR super-resolution image from a single frame.
+
+    Args:
+        image: 2D array (H, W) — single fluorescence frame.
+        order: MSSR order (1 or 2). Higher order = more sharpening.
+        kernel_sigma: Gaussian kernel sigma for mean-shift computation.
+
+    Returns:
+        2D array (H, W) — MSSR enhanced image, normalized to [0, 1].
+    """
+    image = image.astype(np.float64)
+    H, W = image.shape
+
+    # Compute intensity-weighted mean shift
+    # Numerator: Σ K(x-xi) * xi * I(xi) for each coordinate
+    Ix = image * np.arange(W)[np.newaxis, :]  # intensity * x-coord
+    Iy = image * np.arange(H)[:, np.newaxis]  # intensity * y-coord
+
+    # Smooth with Gaussian kernel
+    smooth_I = gaussian_filter(image, sigma=kernel_sigma) + 1e-10
+    smooth_Ix = gaussian_filter(Ix, sigma=kernel_sigma)
+    smooth_Iy = gaussian_filter(Iy, sigma=kernel_sigma)
+
+    # Mean position (intensity-weighted centroid in local neighborhood)
+    mean_x = smooth_Ix / smooth_I
+    mean_y = smooth_Iy / smooth_I
+
+    # Current pixel positions
+    x_grid = np.arange(W)[np.newaxis, :] * np.ones((H, 1))
+    y_grid = np.arange(H)[:, np.newaxis] * np.ones((1, W))
+
+    # Mean shift vector
+    shift_x = mean_x - x_grid
+    shift_y = mean_y - y_grid
+
+    # Mean shift magnitude
+    shift_mag = np.sqrt(shift_x**2 + shift_y**2)
+
+    # MSSR image: sharpen peaks, suppress slopes
+    epsilon = np.percentile(shift_mag[shift_mag > 0], 5) if np.any(shift_mag > 0) else 0.1
+
+    if order == 1:
+        mssr = image / (shift_mag + epsilon)
+    else:
+        # Order 2: use gradient of shift magnitude for extra sharpening
+        grad_x = np.gradient(shift_mag, axis=1)
+        grad_y = np.gradient(shift_mag, axis=0)
+        grad_mag = np.sqrt(grad_x**2 + grad_y**2)
+        mssr = image / ((shift_mag + epsilon) * (grad_mag + epsilon))
+
+    # Normalize to [0, 1]
+    mssr = np.maximum(mssr, 0)
+    vmax = np.percentile(mssr, 99.5)
+    if vmax > 0:
+        mssr = np.clip(mssr / vmax, 0, 1)
+
+    return mssr
+
+
+def compute_temporal_mssr(images: np.ndarray, order: int = 1,
+                           kernel_sigma: float = 1.0) -> np.ndarray:
+    """Compute temporal MSSR by averaging MSSR across frames.
+
+    Combines the single-frame resolution of MSSR with temporal
+    averaging for improved SNR.
+
+    Args:
+        images: 3D array (T, H, W).
+        order: MSSR order (1 or 2).
+        kernel_sigma: Gaussian kernel sigma.
+
+    Returns:
+        2D array (H, W) — temporally averaged MSSR image.
+    """
+    T = images.shape[0]
+    accumulated = np.zeros(images.shape[1:], dtype=np.float64)
+
+    for t in range(T):
+        accumulated += compute_mssr(images[t], order=order, kernel_sigma=kernel_sigma)
+
+    result = accumulated / T
+    vmax = result.max()
+    if vmax > 0:
+        result /= vmax
+    return result

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -116,6 +116,38 @@
             </div>
         </div>
 
+        <!-- MSSR Processing -->
+        <div class="control-section">
+            <h3>MSSR Super-Resolution</h3>
+            <div class="section-body">
+                <div class="form-group">
+                    <label for="mssr-mode">Mode</label>
+                    <select id="mssr-mode">
+                        <option value="single">MSSR (single frame)</option>
+                        <option value="temporal">MSSR (temporal)</option>
+                    </select>
+                </div>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="mssr-order">Order</label>
+                        <select id="mssr-order">
+                            <option value="1">1 (standard)</option>
+                            <option value="2">2 (extra sharp)</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="mssr-sigma">Kernel Sigma</label>
+                        <input type="number" id="mssr-sigma" value="1.0" min="0.5" max="5.0" step="0.1">
+                    </div>
+                </div>
+                <div class="form-group" id="mssr-frame-group">
+                    <label for="mssr-frame">Frame Index</label>
+                    <input type="number" id="mssr-frame" value="0" min="0" step="1">
+                </div>
+                <button class="btn btn-primary" id="btn-mssr" disabled style="width:100%">Process MSSR</button>
+            </div>
+        </div>
+
         <!-- Display Options -->
         <div class="control-section">
             <h3>Display</h3>
@@ -216,5 +248,48 @@
 <script src="/static/js/websocket.js"></script>
 <script src="/static/js/renderer.js"></script>
 <script src="/static/js/app.js"></script>
+<script>
+(function () {
+    var btnMSSR = document.getElementById('btn-mssr');
+    var btnSimulate = document.getElementById('btn-simulate');
+    var mssrMode = document.getElementById('mssr-mode');
+    var mssrFrameGroup = document.getElementById('mssr-frame-group');
+
+    // Enable MSSR button when simulation data is available
+    if (btnSimulate) {
+        btnSimulate.addEventListener('click', function () {
+            setTimeout(function () { btnMSSR.disabled = false; }, 2000);
+        });
+    }
+
+    // Toggle frame index visibility based on mode
+    mssrMode.addEventListener('change', function () {
+        mssrFrameGroup.style.display = this.value === 'single' ? '' : 'none';
+    });
+
+    btnMSSR.addEventListener('click', function () {
+        btnMSSR.disabled = true;
+        var params = {
+            mode: mssrMode.value,
+            order: parseInt(document.getElementById('mssr-order').value),
+            kernel_sigma: parseFloat(document.getElementById('mssr-sigma').value),
+            frame_index: parseInt(document.getElementById('mssr-frame').value) || 0,
+        };
+        fetch('/api/process-mssr', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(params),
+        })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            btnMSSR.disabled = false;
+            if (data.status === 'ok' && typeof window.displayResult === 'function') {
+                window.displayResult('MSSR (' + params.mode + ', order ' + params.order + ')', data.result);
+            }
+        })
+        .catch(function () { btnMSSR.disabled = false; });
+    });
+})();
+</script>
 </body>
 </html>

--- a/tests/test_mssr.py
+++ b/tests/test_mssr.py
@@ -1,0 +1,139 @@
+"""
+Tests for MSSR (Mean-Shift Super Resolution) module.
+
+Validates shape, normalization, peak sharpening, and temporal
+averaging behavior.
+"""
+
+import sys
+import os
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.simulation.mssr import compute_mssr, compute_temporal_mssr
+
+
+def _make_gaussian_spot(size=32, center=None, sigma=3.0, brightness=1000.0, background=50.0):
+    """Create a synthetic image with a single Gaussian emitter."""
+    if center is None:
+        center = (size // 2, size // 2)
+    y, x = np.mgrid[0:size, 0:size]
+    spot = brightness * np.exp(-((x - center[1])**2 + (y - center[0])**2) / (2 * sigma**2))
+    return spot + background
+
+
+def test_mssr_shape():
+    """MSSR output should have the same shape as input."""
+    image = np.random.rand(32, 32) * 100 + 10
+    result = compute_mssr(image, order=1, kernel_sigma=1.0)
+    assert result.shape == image.shape, f"Expected {image.shape}, got {result.shape}"
+
+    result2 = compute_mssr(image, order=2, kernel_sigma=1.0)
+    assert result2.shape == image.shape, f"Expected {image.shape}, got {result2.shape}"
+    print("  PASS: MSSR output shape matches input shape")
+
+
+def test_mssr_normalized():
+    """MSSR output should be normalized to [0, 1]."""
+    image = _make_gaussian_spot(size=32, sigma=3.0)
+    result = compute_mssr(image, order=1, kernel_sigma=1.5)
+    assert result.min() >= 0.0, f"Min should be >= 0, got {result.min()}"
+    assert result.max() <= 1.0 + 1e-10, f"Max should be <= 1, got {result.max()}"
+    print("  PASS: MSSR output is normalized to [0, 1]")
+
+
+def test_mssr_sharpens_peaks():
+    """MSSR should sharpen peaks -- the peak pixel should dominate more.
+
+    We compare the peak pixel value relative to the image maximum in
+    a ring around the peak. In the original Gaussian, pixels near the
+    center are close to the peak value. In MSSR, the drop-off from the
+    peak should be much steeper (sharper).
+    """
+    image = _make_gaussian_spot(size=64, center=(32, 32), sigma=4.0,
+                                 brightness=1000.0, background=50.0)
+    result = compute_mssr(image, order=1, kernel_sigma=2.0)
+
+    # Normalize original to [0, 1] for comparison
+    img_norm = (image - image.min()) / (image.max() - image.min())
+
+    # Measure the ratio of the peak pixel to its immediate neighbors
+    # A sharper peak will have a larger peak-to-neighbor ratio
+    def peak_to_neighbor_ratio(img, cy=32, cx=32):
+        peak = img[cy, cx]
+        neighbors = [img[cy-1, cx], img[cy+1, cx], img[cy, cx-1], img[cy, cx+1]]
+        mean_neighbor = np.mean(neighbors) + 1e-15
+        return peak / mean_neighbor
+
+    orig_ratio = peak_to_neighbor_ratio(img_norm)
+    mssr_ratio = peak_to_neighbor_ratio(result)
+
+    assert mssr_ratio > orig_ratio, \
+        f"MSSR should have steeper peak drop-off: MSSR={mssr_ratio:.2f} vs orig={orig_ratio:.2f}"
+    print(f"  PASS: MSSR sharpens peaks (peak/neighbor ratio {orig_ratio:.2f} -> {mssr_ratio:.2f})")
+
+
+def test_mssr_order2_sharper_than_order1():
+    """Order 2 MSSR should produce sharper peaks than order 1.
+
+    Measured by comparing the fraction of energy concentrated in
+    the peak region (5x5 around center) vs the total image energy.
+    """
+    image = _make_gaussian_spot(size=64, center=(32, 32), sigma=4.0,
+                                 brightness=1000.0, background=50.0)
+    r1 = compute_mssr(image, order=1, kernel_sigma=2.0)
+    r2 = compute_mssr(image, order=2, kernel_sigma=2.0)
+
+    # Energy concentration: fraction of sum in 5x5 center patch
+    def peak_concentration(img, cy=32, cx=32, patch=3):
+        total = img.sum() + 1e-10
+        peak = img[cy-patch:cy+patch+1, cx-patch:cx+patch+1].sum()
+        return peak / total
+
+    conc1 = peak_concentration(r1)
+    conc2 = peak_concentration(r2)
+
+    assert conc2 >= conc1, \
+        f"Order 2 should concentrate more energy at peak: {conc2:.4f} vs {conc1:.4f}"
+    print(f"  PASS: Order 2 sharper than order 1 (concentration {conc1:.4f} -> {conc2:.4f})")
+
+
+def test_temporal_mssr():
+    """Temporal MSSR should produce a valid 2D result from a 3D stack."""
+    np.random.seed(42)
+    T, H, W = 20, 32, 32
+    # Stack of noisy Gaussian spots
+    images = np.zeros((T, H, W))
+    for t in range(T):
+        images[t] = _make_gaussian_spot(size=32, sigma=3.0,
+                                         brightness=500 + np.random.randn() * 100,
+                                         background=50.0)
+        images[t] += np.random.randn(H, W) * 20  # add noise
+
+    result = compute_temporal_mssr(images, order=1, kernel_sigma=1.5)
+
+    assert result.shape == (H, W), f"Expected ({H}, {W}), got {result.shape}"
+    assert result.min() >= 0.0, f"Min should be >= 0, got {result.min()}"
+    assert result.max() <= 1.0 + 1e-10, f"Max should be <= 1, got {result.max()}"
+    print("  PASS: Temporal MSSR produces valid 2D result")
+
+
+def test_mssr_constant_image():
+    """MSSR of a constant image should not crash and produce valid output."""
+    image = np.ones((16, 16)) * 100.0
+    result = compute_mssr(image, order=1, kernel_sigma=1.0)
+    assert result.shape == (16, 16)
+    assert np.all(np.isfinite(result)), "MSSR of constant image should be finite"
+    print("  PASS: MSSR handles constant image gracefully")
+
+
+if __name__ == "__main__":
+    print("=== MSSR Tests ===")
+    test_mssr_shape()
+    test_mssr_normalized()
+    test_mssr_sharpens_peaks()
+    test_mssr_order2_sharper_than_order1()
+    test_temporal_mssr()
+    test_mssr_constant_image()
+    print("=== All MSSR tests passed ===")


### PR DESCRIPTION
## Summary
- MSSR: I(x)/(|m(x)|+ε) — single-frame super-resolution via mean-shift
- Order 1 (basic) and order 2 (gradient-enhanced)
- Temporal mode averages across frames for better SNR
- 6 new tests

@codex MSSR uses percentile(5%) as epsilon to avoid division by zero. Is this robust across different imaging conditions? Torres-García 2022 suggests adaptive epsilon. What would you use? 🔬

**CODE REVIEW ONLY.**
🤖 Generated with [Claude Code](https://claude.ai/claude-code)