### PR TITLE
Feat: /api/version, deployment docs, end-to-end API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,10 +308,16 @@ result = pipeline.process(image_stack)
 
 ## Documentation
 
+- [User Guide](docs/user_guide.md) -- Operator-focused walkthrough, recipes, troubleshooting
 - [SOFI Theory](docs/sofi_theory.md) -- Exhaustive mathematical foundation with derivations
 - [System Architecture](docs/architecture.md) -- Component design and data flow
 - [Development History](docs/development_history.md) -- Project evolution and decisions
 - [References](docs/references.md) -- 20+ academic references (Dertinger, Geissbuehler, Basak, etc.)
+
+### Domain diagrams
+
+- [Optical setup](docs/svg/optical_setup.svg) -- Widefield 532 nm / NA 1.4 / sCMOS layout with physical scales
+- [Fluctuation analysis](docs/svg/fluctuation_analysis.svg) -- From blinking trace to lagged products to cumulant map
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -241,11 +241,13 @@ FASL_SOFI_QDOTS/
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/` | Serve the frontend application |
-| `GET` | `/health` | Health check (`{"status": "ok", "version": "2.0.0"}`) |
+| `GET` | `/health` | Health check (`{"status": "ok", "version": "<app version>"}`, sourced from `app.__version__`) |
+| `GET` | `/api/version` | Version probe (`{"version": "<app version>", "service": "FASL SOFI QDOTS"}`) |
 | `GET` | `/docs` | Swagger UI (auto-generated) |
 | `GET` | `/redoc` | ReDoc documentation |
 | `POST` | `/api/simulate` | Generate synthetic blinking data |
 | `POST` | `/api/process` | Run SOFI cumulant pipeline |
+| `POST` | `/api/upload-tiff` | Upload a TIFF stack for processing |
 | `GET` | `/api/state` | Current application state |
 
 ### WebSocket
@@ -309,6 +311,7 @@ result = pipeline.process(image_stack)
 ## Documentation
 
 - [User Guide](docs/user_guide.md) -- Operator-focused walkthrough, recipes, troubleshooting
+- [Deployment](docs/deployment.md) -- cPanel Passenger, Uvicorn + Nginx, systemd, static caching
 - [SOFI Theory](docs/sofi_theory.md) -- Exhaustive mathematical foundation with derivations
 - [System Architecture](docs/architecture.md) -- Component design and data flow
 - [Development History](docs/development_history.md) -- Project evolution and decisions

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from pathlib import Path
 
+from . import __version__
 from .api.routes import router
 
 # Application metadata
@@ -32,7 +33,7 @@ app = FastAPI(
         "Simulates quantum dot blinking and computes cumulant-based "
         "super-resolution images (orders 2-6)."
     ),
-    version="2.0.0",
+    version=__version__,
     docs_url="/docs",
     redoc_url="/redoc",
 )
@@ -53,5 +54,21 @@ async def root():
 
 @app.get("/health")
 async def health():
-    """Health check endpoint."""
-    return {"status": "ok", "service": "FASL SOFI QDOTS", "version": "2.0.0"}
+    """Health check endpoint.
+
+    Returns a small JSON payload suitable for load-balancer / uptime probes.
+    Version is sourced from ``app.__version__`` so there is a single source
+    of truth for the deployed build.
+    """
+    return {"status": "ok", "service": "FASL SOFI QDOTS", "version": __version__}
+
+
+@app.get("/api/version")
+async def api_version():
+    """Application version endpoint.
+
+    Dedicated version probe for deployment tooling (cPanel Passenger,
+    systemd, CI). Returns the same ``__version__`` as ``/health`` so
+    smoke tests can pin a specific release.
+    """
+    return {"version": __version__, "service": "FASL SOFI QDOTS"}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,7 @@ The application runs on port **8007** by default.
 ## Related Documents
 
 - `docs/user_guide.md` — end-user walkthrough, recipes, troubleshooting
+- `docs/deployment.md` — cPanel Passenger, Uvicorn + Nginx, systemd, static caching
 - `docs/sofi_theory.md` — mathematical foundation (cumulants, moments, bSOFI)
 - `docs/references.md` — primary literature (Dertinger, Geissbuehler, Basak, ...)
 - `docs/svg/optical_setup.svg` — widefield microscope diagram with physical scales

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,3 +91,11 @@ Images are transferred as base64-encoded float32 arrays with shape metadata. The
 ## Port Configuration
 
 The application runs on port **8007** by default.
+
+## Related Documents
+
+- `docs/user_guide.md` — end-user walkthrough, recipes, troubleshooting
+- `docs/sofi_theory.md` — mathematical foundation (cumulants, moments, bSOFI)
+- `docs/references.md` — primary literature (Dertinger, Geissbuehler, Basak, ...)
+- `docs/svg/optical_setup.svg` — widefield microscope diagram with physical scales
+- `docs/svg/fluctuation_analysis.svg` — trace → lagged products → cumulant map

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,248 @@
+# Deployment Guide — FASL SOFI QDOTS
+
+This guide covers production deployment of the FASL SOFI QDOTS FastAPI
+application in three common environments:
+
+1. **cPanel Passenger** (shared hosting, Python App manager)
+2. **Uvicorn + Nginx** (VPS or bare-metal, reverse proxy)
+3. **systemd** (process supervision under a `fasl-sofi` unit)
+
+It also includes guidance on static asset caching, log rotation, and
+post-deploy smoke tests using the `/health` and `/api/version`
+endpoints.
+
+> **Service slug:** `sofi` &nbsp;·&nbsp; **Port:** `8007` (see
+> [CAOS_MANAGE port ledger](../../../\_Web\_Projects/CAOS_MANAGE/infrastructure/vps/hetzner-fasl-prod/README.md))
+
+---
+
+## 1. cPanel Passenger (Python App)
+
+The repo ships `passenger_wsgi.py` that exposes `application = app.main:app`.
+cPanel's "Setup Python App" feature reads this file automatically.
+
+### 1.1 Create the Python App
+
+In cPanel → **Setup Python App**:
+
+| Field | Value |
+|---|---|
+| Python version | 3.12+ |
+| Application root | `/home/<user>/apps/sofi` |
+| Application URL | `sofi.<domain>` (or a path) |
+| Application startup file | `passenger_wsgi.py` |
+| Application entry point | `application` |
+| Passenger log file | `/home/<user>/logs/sofi.log` |
+
+### 1.2 Deploy source
+
+```bash
+cd ~/apps/sofi
+git clone https://github.com/fsantibanezleal/FASL_SOFI_QDOTS.git .
+source /home/<user>/virtualenv/apps/sofi/3.12/bin/activate
+pip install -r requirements.txt
+```
+
+### 1.3 Restart
+
+Hit **Restart** in the Python App manager, or `touch tmp/restart.txt` at the
+app root.
+
+### 1.4 Smoke test
+
+```bash
+curl -s https://sofi.<domain>/health
+# {"status":"ok","service":"FASL SOFI QDOTS","version":"2.0.0"}
+
+curl -s https://sofi.<domain>/api/version
+# {"version":"2.0.0","service":"FASL SOFI QDOTS"}
+```
+
+### 1.5 Passenger notes
+
+- Passenger handles ASGI protocol negotiation automatically when the startup
+  file is `passenger_wsgi.py` and the callable resolves to a FastAPI app.
+- WebSocket (`/ws`) support depends on the cPanel server's Passenger build.
+  If the upgrade handshake fails, fall back to polling or move the
+  WebSocket-heavy frontend routes behind the Nginx deployment below.
+
+---
+
+## 2. Uvicorn + Nginx (VPS)
+
+For any non-shared environment, run Uvicorn directly behind Nginx. This
+is the preferred topology for production: it gives you clean WebSocket
+support, clear process ownership, and per-endpoint log separation.
+
+### 2.1 Install
+
+```bash
+sudo useradd -r -s /usr/sbin/nologin fasl-sofi
+sudo mkdir -p /opt/fasl-sofi
+sudo chown fasl-sofi:fasl-sofi /opt/fasl-sofi
+sudo -u fasl-sofi git clone https://github.com/fsantibanezleal/FASL_SOFI_QDOTS.git /opt/fasl-sofi
+sudo -u fasl-sofi python3.12 -m venv /opt/fasl-sofi/.venv
+sudo -u fasl-sofi /opt/fasl-sofi/.venv/bin/pip install -r /opt/fasl-sofi/requirements.txt
+```
+
+### 2.2 Run Uvicorn
+
+Bind to `127.0.0.1:8007` so only Nginx can reach it:
+
+```bash
+sudo -u fasl-sofi /opt/fasl-sofi/.venv/bin/uvicorn app.main:app \
+  --host 127.0.0.1 --port 8007 --workers 2 --proxy-headers
+```
+
+### 2.3 Nginx server block
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name sofi.fasl-work.com;
+
+    ssl_certificate     /etc/letsencrypt/live/sofi.fasl-work.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/sofi.fasl-work.com/privkey.pem;
+
+    # ----- Static assets (served by Uvicorn, but cache aggressively) -----
+    location /static/ {
+        proxy_pass http://127.0.0.1:8007;
+        proxy_set_header Host $host;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800, immutable";
+    }
+
+    # ----- WebSocket upgrade for /ws -----
+    location /ws {
+        proxy_pass http://127.0.0.1:8007;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # ----- Everything else (REST API + SPA) -----
+    location / {
+        proxy_pass http://127.0.0.1:8007;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 200m;    # TIFF stacks can be large
+    }
+
+    # ----- Health probes (bypass upstream logs) -----
+    location = /health {
+        proxy_pass http://127.0.0.1:8007;
+        access_log off;
+    }
+}
+```
+
+Reload:
+
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+---
+
+## 3. systemd unit template
+
+Save as `/etc/systemd/system/fasl-sofi.service`:
+
+```ini
+[Unit]
+Description=FASL SOFI QDOTS (FastAPI + Uvicorn, port 8007)
+After=network.target
+
+[Service]
+Type=simple
+User=fasl-sofi
+Group=fasl-sofi
+WorkingDirectory=/opt/fasl-sofi
+Environment="PATH=/opt/fasl-sofi/.venv/bin"
+ExecStart=/opt/fasl-sofi/.venv/bin/uvicorn app.main:app \
+    --host 127.0.0.1 --port 8007 --workers 2 --proxy-headers \
+    --log-level info
+Restart=on-failure
+RestartSec=5s
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now fasl-sofi
+sudo systemctl status fasl-sofi
+```
+
+### 3.1 Log rotation
+
+Uvicorn logs to stdout/stderr → journald. To archive them:
+
+```bash
+sudo journalctl -u fasl-sofi --since "yesterday" > /var/log/fasl-sofi.$(date +%F).log
+```
+
+Or add a `/etc/logrotate.d/fasl-sofi` rule if you redirect logs to a file
+via `StandardOutput=append:/var/log/fasl-sofi.log`.
+
+---
+
+## 4. Static asset caching
+
+Static files under `app/static/` are served by the FastAPI mount
+`/static`. In the Nginx block above the `expires 7d` + `Cache-Control:
+public, max-age=604800, immutable` directives let browsers cache JS/CSS
+for a week. For hash-busted assets bump the version suffix in the
+filename to invalidate caches.
+
+For dev parity, Uvicorn already sends ETags on `StaticFiles` responses —
+no extra config needed.
+
+---
+
+## 5. Post-deploy smoke tests
+
+After each deploy, run these three probes:
+
+```bash
+# 1. Liveness
+curl -fsS https://sofi.<domain>/health
+
+# 2. Version pin
+curl -fsS https://sofi.<domain>/api/version
+
+# 3. REST round-trip (simulate -> process)
+curl -fsS -X POST https://sofi.<domain>/api/simulate \
+  -H 'content-type: application/json' \
+  -d '{"num_frames":60,"image_size":32,"num_emitters":4,"seed":42}' | head -c 200
+```
+
+The API test suite covers these flows end-to-end:
+
+```bash
+python -m pytest tests/test_api.py -v
+```
+
+---
+
+## 6. Cross-references
+
+- [System Architecture](architecture.md) — runtime component diagram
+- [User Guide](user_guide.md) — operator workflows once deployed
+- [CAOS_MANAGE deployments/sofi.md](../../../\_Web\_Projects/CAOS_MANAGE/deployments/sofi.md) — environment-specific secrets and host notes
+- [CAOS_MANAGE VPS ledger](../../../\_Web\_Projects/CAOS_MANAGE/infrastructure/vps/hetzner-fasl-prod/README.md) — global port + service ownership

--- a/docs/svg/fluctuation_analysis.svg
+++ b/docs/svg/fluctuation_analysis.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 460" font-family="Segoe UI, Arial, sans-serif" font-size="13">
+  <defs>
+    <marker id="arr2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333"/>
+    </marker>
+  </defs>
+  <rect width="900" height="460" fill="#fafafa"/>
+  <text x="450" y="28" text-anchor="middle" font-size="18" font-weight="700">Fluctuation Analysis — From Blinking Trace to Cumulant Image</text>
+
+  <!-- Panel A: blinking trace -->
+  <g transform="translate(40,60)">
+    <rect width="260" height="160" fill="#fff" stroke="#ccc"/>
+    <text x="130" y="-8" text-anchor="middle" font-weight="700">A. Intensity trace F(r₀, t)</text>
+    <!-- axes -->
+    <line x1="20" y1="140" x2="250" y2="140" stroke="#333"/>
+    <line x1="20" y1="20"  x2="20"  y2="140" stroke="#333"/>
+    <text x="250" y="155" font-size="10" text-anchor="end">t (frames)</text>
+    <text x="10"  y="25"  font-size="10">F</text>
+    <!-- telegraph-like trace -->
+    <polyline fill="none" stroke="#1f6feb" stroke-width="1.6"
+      points="20,110 40,110 40,40 70,40 70,115 95,115 95,45 125,45 125,112 150,112 150,40 175,40 175,115 205,115 205,48 235,48 235,110 250,110"/>
+    <!-- mean -->
+    <line x1="20" y1="80" x2="250" y2="80" stroke="#7e57c2" stroke-dasharray="4 4"/>
+    <text x="250" y="78" font-size="10" text-anchor="end" fill="#7e57c2">⟨F⟩</text>
+  </g>
+
+  <!-- arrow -->
+  <line x1="310" y1="140" x2="355" y2="140" stroke="#333" stroke-width="2" marker-end="url(#arr2)"/>
+  <text x="332" y="130" font-size="11" text-anchor="middle">δF = F−⟨F⟩</text>
+
+  <!-- Panel B: centered trace + lagged products -->
+  <g transform="translate(360,60)">
+    <rect width="260" height="160" fill="#fff" stroke="#ccc"/>
+    <text x="130" y="-8" text-anchor="middle" font-weight="700">B. Lagged products δF(t)·δF(t+τ)</text>
+    <line x1="20" y1="80" x2="250" y2="80" stroke="#333"/>
+    <text x="250" y="95" font-size="10" text-anchor="end">t</text>
+    <text x="12"  y="25" font-size="10">δF·δF</text>
+    <!-- bars above and below zero -->
+    <g fill="#4cc38a" stroke="#2a7f4e">
+      <rect x="30"  y="50" width="10" height="30"/>
+      <rect x="55"  y="30" width="10" height="50"/>
+      <rect x="80"  y="40" width="10" height="40"/>
+      <rect x="105" y="60" width="10" height="20"/>
+      <rect x="155" y="35" width="10" height="45"/>
+      <rect x="180" y="50" width="10" height="30"/>
+      <rect x="230" y="45" width="10" height="35"/>
+    </g>
+    <g fill="#e24a4a" stroke="#7a0b0b">
+      <rect x="130" y="80" width="10" height="25"/>
+      <rect x="205" y="80" width="10" height="15"/>
+    </g>
+    <text x="130" y="150" text-anchor="middle" font-size="11">positive products from correlated fluctuations</text>
+  </g>
+
+  <line x1="630" y1="140" x2="675" y2="140" stroke="#333" stroke-width="2" marker-end="url(#arr2)"/>
+  <text x="652" y="130" font-size="11" text-anchor="middle">⟨ ⟩_t</text>
+
+  <!-- Panel C: cumulant image -->
+  <g transform="translate(680,60)">
+    <rect width="180" height="160" fill="#fff" stroke="#ccc"/>
+    <text x="90" y="-8" text-anchor="middle" font-weight="700">C. C_n(r) map</text>
+    <!-- heatmap mock: small grid -->
+    <g>
+      <rect x="15"  y="15" width="150" height="130" fill="#111"/>
+      <circle cx="55"  cy="55"  r="22" fill="#ffcf33" opacity="0.85"/>
+      <circle cx="120" cy="70"  r="18" fill="#ff8a33" opacity="0.85"/>
+      <circle cx="90"  cy="110" r="15" fill="#ff5c33" opacity="0.85"/>
+    </g>
+    <text x="90" y="158" text-anchor="middle" font-size="10">PSF narrowed by √n</text>
+  </g>
+
+  <!-- Formula row -->
+  <g transform="translate(40,260)">
+    <rect width="820" height="60" rx="8" fill="#eef3ff" stroke="#1f6feb"/>
+    <text x="20" y="25" font-weight="700">Auto-cumulant (order n, consecutive lags):</text>
+    <text x="20" y="48" font-family="Consolas, monospace">
+      C_n(r) = κ_n[ F(r, t), F(r, t+1), …, F(r, t+n−1) ] = Σ_k ε_k^n · κ_n[s_k] · U^n(r − r_k)
+    </text>
+  </g>
+
+  <!-- Order comparison row -->
+  <g transform="translate(40,340)">
+    <text x="0" y="15" font-weight="700">Order progression — effective PSF σ_eff = σ_PSF / √n</text>
+    <g font-size="11">
+      <rect x="0"   y="30" width="140" height="90" fill="#fff" stroke="#ccc"/>
+      <text x="70"  y="48" text-anchor="middle" font-weight="700">n = 2</text>
+      <circle cx="70" cy="82" r="26" fill="#4cc38a" opacity="0.7"/>
+      <text x="70" y="108" text-anchor="middle">√2× gain — unresolved blob shrinks</text>
+
+      <rect x="160" y="30" width="140" height="90" fill="#fff" stroke="#ccc"/>
+      <text x="230" y="48" text-anchor="middle" font-weight="700">n = 3</text>
+      <circle cx="230" cy="82" r="20" fill="#4cc38a" opacity="0.75"/>
+      <text x="230" y="108" text-anchor="middle">asymmetric, signed</text>
+
+      <rect x="320" y="30" width="140" height="90" fill="#fff" stroke="#ccc"/>
+      <text x="390" y="48" text-anchor="middle" font-weight="700">n = 4</text>
+      <circle cx="370" cy="82" r="12" fill="#4cc38a" opacity="0.85"/>
+      <circle cx="410" cy="82" r="12" fill="#4cc38a" opacity="0.85"/>
+      <text x="390" y="108" text-anchor="middle">two emitters resolved (2× gain)</text>
+
+      <rect x="480" y="30" width="140" height="90" fill="#fff" stroke="#ccc"/>
+      <text x="550" y="48" text-anchor="middle" font-weight="700">n = 6</text>
+      <circle cx="530" cy="82" r="8" fill="#4cc38a" opacity="0.9"/>
+      <circle cx="560" cy="82" r="8" fill="#4cc38a" opacity="0.9"/>
+      <circle cx="545" cy="100" r="7" fill="#4cc38a" opacity="0.9"/>
+      <text x="550" y="120" text-anchor="middle">√6× gain, high-SNR only</text>
+
+      <rect x="640" y="30" width="180" height="90" fill="#fff" stroke="#ccc"/>
+      <text x="730" y="48" text-anchor="middle" font-weight="700">+ SOFIX (deconv.)</text>
+      <circle cx="705" cy="82" r="5" fill="#ffcf33"/>
+      <circle cx="735" cy="82" r="5" fill="#ffcf33"/>
+      <circle cx="720" cy="102" r="4" fill="#ffcf33"/>
+      <text x="730" y="118" text-anchor="middle">full n× gain (Fourier + Wiener / R-L)</text>
+    </g>
+  </g>
+</svg>

--- a/docs/svg/optical_setup.svg
+++ b/docs/svg/optical_setup.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 420" font-family="Segoe UI, Arial, sans-serif" font-size="13">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333"/>
+    </marker>
+    <linearGradient id="beam" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#4cc38a" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#4cc38a" stop-opacity="0.85"/>
+    </linearGradient>
+    <linearGradient id="emit" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#e24a4a" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#e24a4a" stop-opacity="0.15"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="900" height="420" fill="#fafafa"/>
+  <text x="450" y="28" text-anchor="middle" font-size="18" font-weight="700">Widefield SOFI Optical Setup (CdSe/ZnS QDots)</text>
+
+  <!-- Laser -->
+  <rect x="20" y="180" width="110" height="60" rx="6" fill="#1f6feb" stroke="#0b3d8e"/>
+  <text x="75" y="205" text-anchor="middle" fill="#fff" font-weight="700">532 nm Laser</text>
+  <text x="75" y="225" text-anchor="middle" fill="#fff" font-size="11">CW excitation</text>
+
+  <!-- Excitation beam (green) -->
+  <rect x="130" y="200" width="160" height="20" fill="url(#beam)"/>
+  <text x="210" y="190" text-anchor="middle" font-size="11">excitation</text>
+
+  <!-- Dichroic mirror -->
+  <line x1="310" y1="165" x2="340" y2="255" stroke="#555" stroke-width="3"/>
+  <text x="325" y="160" text-anchor="middle" font-size="11">dichroic</text>
+
+  <!-- Path up to objective -->
+  <rect x="320" y="130" width="20" height="80" fill="url(#beam)"/>
+  <!-- Objective -->
+  <polygon points="290,100 360,100 345,60 305,60" fill="#bfc9d1" stroke="#333"/>
+  <text x="325" y="80" text-anchor="middle" font-weight="700" font-size="12">100× / NA 1.4</text>
+
+  <!-- Oil + coverslip + sample -->
+  <rect x="280" y="40" width="90" height="8" fill="#ffe29a" stroke="#9a7a00"/>
+  <text x="380" y="48" font-size="11">immersion oil</text>
+  <rect x="260" y="28" width="130" height="6" fill="#cfe8ff" stroke="#2a6fb8"/>
+  <text x="400" y="34" font-size="11">coverslip</text>
+
+  <!-- QDot sample -->
+  <circle cx="290" cy="20" r="4" fill="#e24a4a"/>
+  <circle cx="305" cy="22" r="4" fill="#e24a4a"/>
+  <circle cx="320" cy="19" r="4" fill="#a23" opacity="0.5"/>
+  <circle cx="340" cy="21" r="4" fill="#e24a4a"/>
+  <circle cx="355" cy="20" r="4" fill="#a23" opacity="0.4"/>
+  <text x="400" y="22" font-size="11">blinking QDots on slide (dense labeling)</text>
+
+  <!-- Emission beam returning -->
+  <rect x="340" y="130" width="18" height="80" fill="url(#emit)"/>
+  <!-- Reflected through dichroic to tube lens -->
+  <rect x="340" y="200" width="220" height="20" fill="url(#emit)"/>
+  <text x="450" y="190" text-anchor="middle" font-size="11">emission (QDot 620 nm)</text>
+
+  <!-- Emission filter -->
+  <rect x="560" y="190" width="14" height="40" fill="#e24a4a" opacity="0.6" stroke="#7a0b0b"/>
+  <text x="567" y="185" text-anchor="middle" font-size="11">emission filter</text>
+
+  <!-- Tube lens -->
+  <ellipse cx="610" cy="210" rx="10" ry="30" fill="#d6e4ff" stroke="#1f6feb"/>
+  <text x="610" y="250" text-anchor="middle" font-size="11">tube lens</text>
+
+  <!-- Beam to camera -->
+  <rect x="620" y="200" width="130" height="20" fill="url(#emit)"/>
+
+  <!-- Camera -->
+  <rect x="750" y="175" width="120" height="70" rx="6" fill="#222" stroke="#000"/>
+  <text x="810" y="200" text-anchor="middle" fill="#fff" font-weight="700">sCMOS</text>
+  <text x="810" y="218" text-anchor="middle" fill="#fff" font-size="11">100 Hz, 16-bit</text>
+  <text x="810" y="234" text-anchor="middle" fill="#fff" font-size="11">→ TIFF stack</text>
+
+  <!-- Output arrow -->
+  <line x1="870" y1="300" x2="870" y2="360" stroke="#333" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="810" y="335" font-size="11" text-anchor="middle">frames F(r, t)</text>
+
+  <!-- SOFI pipeline box -->
+  <rect x="660" y="350" width="220" height="55" rx="8" fill="#f2eaff" stroke="#7e57c2"/>
+  <text x="770" y="372" text-anchor="middle" font-weight="700">SOFI pipeline</text>
+  <text x="770" y="390" text-anchor="middle" font-size="11">cumulants → linearize → deconvolve</text>
+
+  <!-- Physical parameters legend -->
+  <rect x="30" y="290" width="330" height="115" rx="8" fill="#ffffff" stroke="#ccc"/>
+  <text x="45" y="310" font-weight="700">Key physical parameters</text>
+  <text x="45" y="330" font-size="11">• Abbe resolution: d = λ/(2·NA) ≈ 620/(2·1.4) ≈ 221 nm</text>
+  <text x="45" y="348" font-size="11">• Pixel scale at sample: ~65 nm/px (100× on sCMOS 6.5 µm)</text>
+  <text x="45" y="366" font-size="11">• PSF σ ≈ 0.21·λ/NA ≈ 93 nm ≈ 1.4 px</text>
+  <text x="45" y="384" font-size="11">• QDot blinking: α_on ≈ 1.5, α_off ≈ 1.6 (power-law)</text>
+  <text x="45" y="400" font-size="11">• SOFI order 4 → σ_eff ≈ 46 nm (2× gain beyond Abbe)</text>
+</svg>

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,160 @@
+# User Guide — FASL SOFI QDOTS
+
+Operator-focused guide for running synthetic SOFI simulations, processing TIFF
+stacks, and interpreting the super-resolution output. For the mathematical
+foundation see `docs/sofi_theory.md`; for system design see
+`docs/architecture.md`.
+
+---
+
+## 1. Launching the Application
+
+### Local development
+```bash
+cd FASL_SOFI_QDOTS
+python -m venv .venv
+source .venv/Scripts/activate        # Windows (Git Bash / bash)
+pip install -r requirements.txt
+python -m uvicorn app.main:app --port 8007
+```
+
+Then open **http://localhost:8007** in your browser.
+
+- Swagger UI: `http://localhost:8007/docs`
+- ReDoc: `http://localhost:8007/redoc`
+- WebSocket progress endpoint: `ws://localhost:8007/ws`
+
+### One-click launcher
+`python run_app.py` starts the Uvicorn server and auto-opens the browser.
+
+---
+
+## 2. The Frontend at a Glance
+
+The single-page UI is divided into three sections:
+
+1. **Simulation controls** — parameters for the synthetic QDot dataset
+   (number of frames, emitters, PSF sigma, brightness, noise).
+2. **Processing controls** — cumulant orders, window size, optional Fourier
+   interpolation, deconvolution selector, linearization toggle.
+3. **Output canvas** — renders the widefield mean image and each SOFI order
+   side-by-side with selectable colormap (gray, hot, viridis, inferno).
+
+A bottom progress bar is driven live by the `/ws` WebSocket.
+
+---
+
+## 3. Running a Synthetic Experiment
+
+### 3.1 Quick recipe — "first working SOFI"
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| `num_frames` | 500 | Enough statistics for orders 2–4 |
+| `image_size` | 64 | Fast, fits typical screens at 4x |
+| `num_emitters` | 20 | Dense enough to show clustering |
+| `psf_sigma` | 2.0 px | ~diffraction-limited (FWHM ≈ 4.7 px) |
+| `brightness` | 1000 | Good SNR against background |
+| `background` | 100 | Realistic widefield baseline |
+| `noise_std` | 20 | Typical sCMOS read noise |
+| `seed` | 42 | Reproducible for screenshots |
+
+### 3.2 Processing recipe
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| `orders` | `[2, 3, 4]` | Cover √2, √3, 2× resolution gain |
+| `window_size` | 100 | Robust to drift / bleaching |
+| `use_fourier` | `true` | Sub-pixel detail for order ≥ 3 |
+| `deconvolution` | `"wiener"` | Reach full n-fold (SOFIX) gain |
+| `linearize` | `true` | Correct the εⁿ brightness bias |
+
+---
+
+## 4. Interpreting the Output
+
+Each order `n` produces three images in the canvas:
+
+- **Raw cumulant** `|C_n(r)|` — shows blob narrowing but brightness scales as εⁿ.
+- **Linearized SOFI** `|C_n|^(1/n)` — restores physical brightness scaling.
+- **SOFIX** (if Fourier + deconvolution enabled) — full n-fold resolution image.
+
+Expected qualitative changes as `n` grows:
+
+| Order | Visible effect on clustered emitters |
+|-------|--------------------------------------|
+| 1 (mean) | Everything blurred into a single blob |
+| 2 | Blob narrows √2 → clusters start to separate |
+| 3 | Asymmetric shapes appear; signed (can go negative) |
+| 4 | Two nearby emitters cleanly resolved |
+| 5–6 | High-order artifacts unless SNR and frame count are generous |
+
+### Signed cumulants
+Odd orders (3, 5) carry a sign; the UI plots `|C_n|` for display.
+The sign encodes the skewness of the intensity trace and is used internally
+by bSOFI flattening — it is **not** a rendering bug.
+
+---
+
+## 5. Loading Experimental TIFF Stacks
+
+`app/simulation/tiff_loader.py` accepts multi-frame TIFF stacks (tifffile +
+Pillow fallback). Typical usage from Python:
+
+```python
+from app.simulation.tiff_loader import load_tiff_stack
+from app.simulation.sofi_pipeline import SOFIPipeline
+
+stack = load_tiff_stack("data/qdots_session01.tif")   # shape (T, H, W)
+pipeline = SOFIPipeline(orders=[2, 3, 4], psf_sigma=2.0,
+                        use_fourier=True, deconvolution="wiener")
+result = pipeline.process(stack)
+```
+
+**Data hygiene checklist before processing:**
+
+- [ ] At least 500 frames (1000+ preferred for orders ≥ 4).
+- [ ] No global bleaching over the window; if present, shorten `window_size`.
+- [ ] Sample drift corrected (SOFI is not translation-invariant inside a window).
+- [ ] Background subtracted or uniform across FOV.
+- [ ] `psf_sigma` matches your microscope (set from the Airy radius in pixels).
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Cumulants look identical to mean image | Emitters do not blink | Increase `num_frames`, verify simulation noise, or check TIFF content |
+| Order-4 image is noisy speckle | Insufficient frames for higher statistics | Raise `num_frames` ≥ 1000 or lower order |
+| SOFIX image has ringing | Over-deconvolved | Switch `deconvolution` from `wiener` to `none`, or lower iterations |
+| Output canvas blank | WebSocket not connected | Reload page, check browser console for `/ws` errors |
+| `psf_sigma` mismatch warning | Deconvolution kernel inconsistent with PSF used in simulation | Use the same `psf_sigma` in both `simulate` and `process` |
+| High-memory error on large stacks | Entire stack held in RAM | Lower `window_size`, crop ROI, or process in batches |
+
+---
+
+## 7. Tests & Validation
+
+```bash
+python -m pytest tests/ -v
+```
+
+- `test_cumulants.py` — validates C₂…C₆ against analytic distributions.
+- `test_emitter.py` — power-law exponent fit from simulated on/off times.
+- `test_mssr.py` — Mean-Shift super-resolution unit tests.
+- `test_pipeline.py` — end-to-end resolution gain check.
+
+A passing suite is the minimum pre-commit gate.
+
+---
+
+## 8. API Quick Reference
+
+- `POST /api/simulate` → `{ "frames": [...], "mean_image": [...], "shape": [T,H,W] }`
+- `POST /api/process`  → `{ "cumulant_images": {...}, "sofi_images": {...} }`
+- `GET  /api/state`    → current simulation + processing parameters
+- `WS   /ws`           → `{ "type": "progress", "step": "...", "progress": 0.0–1.0 }`
+
+See `docs/architecture.md` for the full module map and `README.md` for the
+parameter tables.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ numpy==2.4.3
 pydantic==2.12.5
 pydantic_core==2.41.5
 python-dotenv==1.2.2
+python-multipart==0.0.26
 PyYAML==6.0.3
 scipy==1.17.1
 starlette==1.0.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,133 @@
+"""
+End-to-end FastAPI route tests.
+
+Covers the HTTP surface that the production frontend and deployment
+probes rely on:
+
+    - GET /health
+    - GET /api/version
+    - POST /api/simulate -> POST /api/process happy path
+
+The simulate -> process flow is exercised with small parameters so the
+test stays well under a second on CI. Decoded cumulant arrays are
+validated for shape and finiteness.
+"""
+
+import base64
+import os
+import sys
+
+import numpy as np
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app import __version__
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def _decode_float_image(b64: str, shape):
+    """Decode a base64 float32 payload produced by routes._image_to_base64.
+
+    The routes helper normalizes to [0, 1] and packs raw float32 bytes;
+    we mirror that here so the test can reason about the decoded array.
+    """
+    raw = base64.b64decode(b64)
+    arr = np.frombuffer(raw, dtype=np.float32)
+    return arr.reshape(shape)
+
+
+def test_health_returns_version_from_init():
+    """/health must source its version from app.__version__."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["version"] == __version__
+
+
+def test_api_version_endpoint():
+    """/api/version is a dedicated probe returning the same version."""
+    response = client.get("/api/version")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["version"] == __version__
+    assert payload["service"] == "FASL SOFI QDOTS"
+
+
+def test_simulate_then_process_happy_path():
+    """POST /api/simulate then POST /api/process must return finite cumulants."""
+    sim_payload = {
+        "num_frames": 60,
+        "image_size": 32,
+        "num_emitters": 4,
+        "psf_sigma": 1.5,
+        "brightness": 1000.0,
+        "background": 50.0,
+        "noise_std": 10.0,
+        "seed": 42,
+    }
+    sim = client.post("/api/simulate", json=sim_payload)
+    assert sim.status_code == 200, sim.text
+    sim_body = sim.json()
+    assert sim_body["status"] == "ok"
+    assert sim_body["num_frames"] == 60
+    assert sim_body["image_size"] == [32, 32]
+
+    proc_payload = {
+        "orders": [2, 3],
+        "window_size": 30,
+        "use_fourier": False,
+        "deconvolution": "none",
+        "linearize": True,
+        "psf_sigma": 1.5,
+    }
+    proc = client.post("/api/process", json=proc_payload)
+    assert proc.status_code == 200, proc.text
+    proc_body = proc.json()
+    assert proc_body["status"] == "ok"
+    assert proc_body["orders"] == [2, 3]
+
+    for order in ("2", "3"):
+        entry = proc_body["results"][order]
+        shape = tuple(entry["shape"])
+        # Cumulant images are at least as large as the input (n-fold up-sample possible).
+        assert len(shape) == 2
+        assert shape[0] >= 32 and shape[1] >= 32
+        img = _decode_float_image(entry["image"], shape)
+        assert np.isfinite(img).all(), f"Non-finite values in order-{order} cumulant"
+        assert entry["max"] >= entry["min"]
+
+
+def test_process_without_data_returns_400():
+    """/api/process must 400 when simulate has not been called."""
+    # Reset shared state so this test is order-independent.
+    from app.api.routes import app_state
+
+    app_state.images = None
+    app_state.positions = None
+    app_state.mean_image = None
+    app_state.sofi_results = {}
+
+    proc_payload = {
+        "orders": [2],
+        "window_size": 30,
+        "use_fourier": False,
+        "deconvolution": "none",
+        "linearize": True,
+        "psf_sigma": 1.5,
+    }
+    response = client.post("/api/process", json=proc_payload)
+    assert response.status_code == 400
+
+
+if __name__ == "__main__":
+    # Allow running as a plain script for parity with the other tests/*.py files.
+    test_health_returns_version_from_init()
+    test_api_version_endpoint()
+    test_process_without_data_returns_400()
+    test_simulate_then_process_happy_path()
+    print("All API tests passed.")


### PR DESCRIPTION
## Summary

Resolves three queued findings from the 2026-04-18 heavy cycle #2:

- **Closes #20** — /api/version endpoint + /health sourced from `app.__version__`
- **Closes #22** — docs/deployment.md (cPanel Passenger, Uvicorn + Nginx, systemd, static caching)
- **Closes #23** — tests/test_api.py end-to-end via fastapi.testclient

Issue #21 (TIFF upload UX hardening) intentionally left open — larger scope, will follow up.

## Changes

- app/main.py: import `__version__`, refactor /health to use it, add /api/version
- docs/deployment.md (new, ~220 lines): three-environment deployment guide
- tests/test_api.py (new, ~115 lines): 4 API-level tests
- requirements.txt: add python-multipart (needed at import time by UploadFile route)
- README.md: API table gains /api/version and /api/upload-tiff rows; Documentation section gains deployment link
- docs/architecture.md: cross-link deployment doc

## Test plan

- [x] `python -m pytest tests/ -v` — all 46 tests pass (was 42)
- [x] `curl /health` returns version sourced from __init__
- [x] `curl /api/version` returns the same version
- [x] New test guards /api/process 400 when no data loaded