### PR TITLE
Feat: Add POST /api/upload (size-capped + dtype-validated TIFF upload)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ FASL_SOFI_QDOTS/
 | `GET` | `/redoc` | ReDoc documentation |
 | `POST` | `/api/simulate` | Generate synthetic blinking data |
 | `POST` | `/api/process` | Run SOFI cumulant pipeline |
-| `POST` | `/api/upload-tiff` | Upload a TIFF stack for processing |
+| `POST` | `/api/upload` | Upload a TIFF stack (size-capped + dtype-validated). Size cap: env `SOFI_MAX_UPLOAD_MB` (default 100 MB) -> 413 on overflow. Accepted authored dtypes: `uint16`, `float32`, `float64` -> 415 otherwise. |
+| `POST` | `/api/upload-tiff` | Legacy TIFF upload (no size cap / dtype validation; retained for backward compat) |
 | `GET` | `/api/state` | Current application state |
 
 ### WebSocket

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -336,6 +336,168 @@ async def get_state():
     )
 
 
+# Upload size cap: default 100 MB, overridable via env var.
+# The cap is read on each request so tests can adjust it without restarting the app.
+_DEFAULT_MAX_UPLOAD_MB = 100
+_ALLOWED_AUTHORED_DTYPES = {"uint16", "float32", "float64"}
+
+
+def _get_max_upload_bytes() -> int:
+    """Return the current upload cap in bytes.
+
+    Reads ``SOFI_MAX_UPLOAD_MB`` on every call so operators can tune it
+    via environment variable and so tests can monkeypatch the limit
+    without restarting the FastAPI app.
+    """
+    try:
+        mb = int(os.environ.get("SOFI_MAX_UPLOAD_MB", _DEFAULT_MAX_UPLOAD_MB))
+    except ValueError:
+        mb = _DEFAULT_MAX_UPLOAD_MB
+    return max(1, mb) * 1024 * 1024
+
+
+async def _stream_upload_to_tempfile(file: UploadFile, max_bytes: int) -> str:
+    """Stream an UploadFile to a temp file, aborting if it exceeds ``max_bytes``.
+
+    Returns the temp-file path. Raises HTTP 413 before fully buffering when
+    the upload crosses the cap, so oversized files never materialize in RAM
+    as a single buffer.
+    """
+    bytes_read = 0
+    chunk_size = 1024 * 1024  # 1 MB
+    tmp = tempfile.NamedTemporaryFile(suffix=".tiff", delete=False)
+    tmp_path = tmp.name
+    try:
+        while True:
+            chunk = await file.read(chunk_size)
+            if not chunk:
+                break
+            bytes_read += len(chunk)
+            if bytes_read > max_bytes:
+                tmp.close()
+                try:
+                    os.unlink(tmp_path)
+                except Exception:
+                    pass
+                raise HTTPException(
+                    status_code=413,
+                    detail=(
+                        f"Upload exceeds size cap of {max_bytes // (1024 * 1024)} MB. "
+                        "Raise SOFI_MAX_UPLOAD_MB to allow larger files."
+                    ),
+                )
+            tmp.write(chunk)
+        tmp.close()
+        return tmp_path
+    except HTTPException:
+        raise
+    except Exception:
+        tmp.close()
+        try:
+            os.unlink(tmp_path)
+        except Exception:
+            pass
+        raise
+
+
+def _authored_tiff_dtype(path: str) -> Optional[str]:
+    """Return the original dtype name stored in the TIFF, if readable.
+
+    ``load_tiff_stack`` promotes to float64 so we cannot recover the
+    authored dtype from the loaded array. We inspect the file directly
+    via ``tifffile`` when available; if tifffile is absent, returns None
+    and callers treat the upload as dtype-unknown (accepted).
+    """
+    try:
+        import tifffile
+    except ImportError:
+        return None
+    try:
+        with tifffile.TiffFile(path) as tf:
+            if not tf.pages:
+                return None
+            return str(np.dtype(tf.pages[0].dtype).name)
+    except Exception:
+        return None
+
+
+@router.post("/api/upload")
+async def upload_tiff_stack(file: UploadFile = File(...)):
+    """Upload a TIFF stack for SOFI processing (size-capped + dtype-validated).
+
+    Accepts a ``.tif`` / ``.tiff`` file, enforces the configurable size cap
+    (``SOFI_MAX_UPLOAD_MB``, default 100 MB), validates the authored dtype
+    (``uint16`` / ``float32`` / ``float64`` only), loads the stack via
+    ``tiff_loader.load_tiff_stack`` and stores it in ``app_state`` so
+    ``/api/process`` can consume it immediately.
+
+    Returns metadata plus a base64 mean image for the frontend.
+
+    Error codes:
+        - 400: filename extension not .tif/.tiff or the file cannot be decoded
+        - 413: upload exceeds ``SOFI_MAX_UPLOAD_MB``
+        - 415: authored dtype is not one of ``uint16`` / ``float32`` / ``float64``
+    """
+    if file.filename and not file.filename.lower().endswith((".tif", ".tiff")):
+        raise HTTPException(
+            status_code=400,
+            detail="File must be a TIFF (.tif or .tiff) file.",
+        )
+
+    max_bytes = _get_max_upload_bytes()
+    tmp_path = await _stream_upload_to_tempfile(file, max_bytes)
+
+    try:
+        authored_dtype = _authored_tiff_dtype(tmp_path)
+        if authored_dtype is not None and authored_dtype not in _ALLOWED_AUTHORED_DTYPES:
+            raise HTTPException(
+                status_code=415,
+                detail=(
+                    f"Unsupported TIFF dtype '{authored_dtype}'. "
+                    f"Expected one of {sorted(_ALLOWED_AUTHORED_DTYPES)}."
+                ),
+            )
+
+        try:
+            images = load_tiff_stack(tmp_path)
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Failed to load TIFF: {e}")
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except Exception:
+            pass
+
+    # Store in application state (same semantics as /api/upload-tiff).
+    app_state.images = images
+    app_state.positions = None
+    app_state.mean_image = np.mean(images, axis=0)
+    app_state.sofi_results = {}
+    app_state.simulation_params = {
+        "source": "upload",
+        "filename": file.filename,
+        "num_frames": int(images.shape[0]),
+        "image_size": [int(images.shape[1]), int(images.shape[2])],
+        "dtype": authored_dtype or str(images.dtype),
+    }
+
+    mean_b64 = _image_to_base64(app_state.mean_image)
+    H, W = app_state.mean_image.shape
+
+    return {
+        "status": "ok",
+        "source": "upload",
+        "filename": file.filename,
+        "frames": int(images.shape[0]),
+        "height": int(images.shape[1]),
+        "width": int(images.shape[2]),
+        "dtype": authored_dtype or str(images.dtype),
+        "value_range": [float(images.min()), float(images.max())],
+        "mean_image": mean_b64,
+        "mean_shape": [H, W],
+    }
+
+
 @router.post("/api/upload-tiff")
 async def upload_tiff(file: UploadFile = File(...)):
     """Upload a TIFF stack for SOFI processing.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -153,6 +153,7 @@ A passing suite is the minimum pre-commit gate.
 
 - `POST /api/simulate` → `{ "frames": [...], "mean_image": [...], "shape": [T,H,W] }`
 - `POST /api/process`  → `{ "cumulant_images": {...}, "sofi_images": {...} }`
+- `POST /api/upload`   → multipart TIFF upload; 413 over `SOFI_MAX_UPLOAD_MB` (default 100 MB); 415 for authored dtypes other than `uint16` / `float32` / `float64`. Align Nginx `client_max_body_size` with the cap (see `docs/deployment.md`).
 - `GET  /api/state`    → current simulation + processing parameters
 - `WS   /ws`           → `{ "type": "progress", "step": "...", "progress": 0.0–1.0 }`
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ probes rely on:
     - GET /health
     - GET /api/version
     - POST /api/simulate -> POST /api/process happy path
+    - POST /api/upload (TIFF upload with size cap + dtype validation)
 
 The simulate -> process flow is exercised with small parameters so the
 test stays well under a second on CI. Decoded cumulant arrays are
@@ -14,10 +15,12 @@ validated for shape and finiteness.
 """
 
 import base64
+import io
 import os
 import sys
 
 import numpy as np
+import pytest
 from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -124,10 +127,101 @@ def test_process_without_data_returns_400():
     assert response.status_code == 400
 
 
+# --------------- /api/upload (TIFF upload) ---------------
+
+
+def _synth_tiff_bytes(frames: int = 3, size: int = 8, dtype: str = "uint16") -> bytes:
+    """Build an in-memory multi-frame TIFF with the requested dtype.
+
+    Uses tifffile.imwrite so the authored dtype is preserved and our
+    server-side dtype check actually sees what we think it does.
+    """
+    tifffile = pytest.importorskip("tifffile")
+    rng = np.random.default_rng(0)
+    if dtype == "uint16":
+        stack = rng.integers(0, 1000, size=(frames, size, size), dtype=np.uint16)
+    elif dtype == "float32":
+        stack = rng.random((frames, size, size), dtype=np.float32)
+    elif dtype == "float64":
+        stack = rng.random((frames, size, size)).astype(np.float64)
+    elif dtype == "uint8":
+        stack = rng.integers(0, 255, size=(frames, size, size), dtype=np.uint8)
+    else:
+        raise ValueError(f"Unsupported test dtype: {dtype}")
+    buf = io.BytesIO()
+    tifffile.imwrite(buf, stack)
+    return buf.getvalue()
+
+
+def test_upload_accepts_uint16_tiff():
+    """POST /api/upload with a small uint16 TIFF must succeed and populate state."""
+    pytest.importorskip("tifffile")
+    tiff_bytes = _synth_tiff_bytes(frames=3, size=8, dtype="uint16")
+    response = client.post(
+        "/api/upload",
+        files={"file": ("tiny.tiff", tiff_bytes, "image/tiff")},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["source"] == "upload"
+    assert body["frames"] == 3
+    assert body["height"] == 8
+    assert body["width"] == 8
+    assert body["dtype"] == "uint16"
+    assert body["mean_shape"] == [8, 8]
+    # State should reflect the upload so /api/process can consume it.
+    from app.api.routes import app_state
+
+    assert app_state.images is not None
+    assert app_state.images.shape == (3, 8, 8)
+
+
+def test_upload_rejects_wrong_extension():
+    """Non-TIFF filenames must be rejected with 400 before any read."""
+    response = client.post(
+        "/api/upload",
+        files={"file": ("notes.txt", b"hello", "text/plain")},
+    )
+    assert response.status_code == 400
+    assert "TIFF" in response.json()["detail"]
+
+
+def test_upload_rejects_uint8_dtype():
+    """uint8 is not in the allowed authored-dtype set — must 415."""
+    pytest.importorskip("tifffile")
+    tiff_bytes = _synth_tiff_bytes(frames=2, size=8, dtype="uint8")
+    response = client.post(
+        "/api/upload",
+        files={"file": ("u8.tiff", tiff_bytes, "image/tiff")},
+    )
+    assert response.status_code == 415
+    assert "uint8" in response.json()["detail"]
+
+
+def test_upload_enforces_size_cap(monkeypatch):
+    """Exceeding SOFI_MAX_UPLOAD_MB must 413 before the stack is loaded."""
+    pytest.importorskip("tifffile")
+    # A 3x64x64 uint16 TIFF is ~24 KB — well above a 0 MB (forced-1 MB floor) cap
+    # once we craft a larger payload. Pad to >1 MB so we cross the cap deterministically.
+    big_bytes = _synth_tiff_bytes(frames=5, size=512, dtype="uint16")
+    assert len(big_bytes) > 1_048_576, "Crafted TIFF must exceed 1 MB to exercise cap"
+    monkeypatch.setenv("SOFI_MAX_UPLOAD_MB", "1")
+    response = client.post(
+        "/api/upload",
+        files={"file": ("big.tiff", big_bytes, "image/tiff")},
+    )
+    assert response.status_code == 413
+    assert "size cap" in response.json()["detail"]
+
+
 if __name__ == "__main__":
     # Allow running as a plain script for parity with the other tests/*.py files.
     test_health_returns_version_from_init()
     test_api_version_endpoint()
     test_process_without_data_returns_400()
     test_simulate_then_process_happy_path()
+    test_upload_accepts_uint16_tiff()
+    test_upload_rejects_wrong_extension()
+    test_upload_rejects_uint8_dtype()
     print("All API tests passed.")


### PR DESCRIPTION
## Summary

New `POST /api/upload` endpoint for uploading experimental TIFF stacks. It streams the upload to a temp file in 1 MB chunks, enforces a configurable size cap before the file is fully buffered, validates the authored TIFF dtype against an allow-list, and stores the resulting stack in `app_state` so `/api/process` can consume it immediately — the same state contract the `/api/simulate` route uses.

- **Size cap:** `SOFI_MAX_UPLOAD_MB` env var (default 100 MB). Over-sized uploads are rejected with HTTP 413 mid-stream, so a 500 MB file never fully lands in RAM.
- **Dtype validation:** `tifffile` metadata exposes the *authored* dtype (the loader promotes to float64 unconditionally). Accepted: `uint16`, `float32`, `float64`. Everything else (including `uint8`, `int32`) -> HTTP 415.
- **Response schema:** `{status, source: "upload", filename, frames, height, width, dtype, value_range, mean_image, mean_shape}`.
- **Legacy `/api/upload-tiff` route is preserved** so the existing frontend keeps working. A follow-up issue tracks the drag-and-drop widget that will migrate to `/api/upload`.

## Test plan

- `python -m pytest tests/ -q` -> 50/50 passed (46 baseline + 4 new)
  - `test_upload_accepts_uint16_tiff` — 200 OK, `app_state.images.shape == (3, 8, 8)`, dtype echoes `uint16`
  - `test_upload_rejects_wrong_extension` — 400 on `notes.txt`
  - `test_upload_rejects_uint8_dtype` — 415 on a tifffile-authored `uint8` stack
  - `test_upload_enforces_size_cap` — 413 when `SOFI_MAX_UPLOAD_MB=1` and the payload is >1 MB
- Manual end-to-end via `TestClient`: POST a 60x16x16 `uint16` TIFF to `/api/upload` -> 200; subsequent `POST /api/process` (orders=[2], window_size=30) -> 200 with order-2 cumulant decoded successfully. Upload -> process handoff verified working.
- Size-cap boundary: confirmed a >1 MB uint16 TIFF is rejected mid-stream by monkeypatching `SOFI_MAX_UPLOAD_MB=1`; the temp file is cleaned up on abort.

## Notes

- Dtype introspection falls back gracefully when `tifffile` is absent: if the helper returns `None`, we accept the upload and let `load_tiff_stack` (PIL fallback) handle it. This mirrors the loader's own degradation path.
- Size-cap enforcement happens **before** load, because `load_tiff_stack` materializes the full array in RAM. Reading in 1 MB chunks keeps the abort path cheap.
- Considered collapsing `/api/upload-tiff` into `/api/upload` but kept both to avoid breaking the existing frontend. A follow-up issue (frontend drag-and-drop widget) will wire the UI to `/api/upload` and then a cleanup PR can deprecate the legacy route.
- Docs updated: README API table gets a new row with size-cap and dtype notes; `docs/user_guide.md` cross-links `docs/deployment.md` so operators know to align Nginx `client_max_body_size` with the cap.

Closes #21